### PR TITLE
update gpfs_unmount.sh to run from CRON

### DIFF
--- a/client_scripts/gpfs_unmount.sh
+++ b/client_scripts/gpfs_unmount.sh
@@ -31,7 +31,7 @@ is_gpfs_installed() {
 
 get_gpfs_state() {
     [[ $DEBUG -eq 1 ]] && set -x
-    $GPFSBIN/mmgetstate | grep $HOSTNAME | awk '{print $NF}'
+    $GPFSBIN/mmgetstate | grep `hostname -s` | awk '{print $NF}'
 }
 
 


### PR DESCRIPTION
I could never get this script to work when run from a CRON environment. Finally tracked it down to the $HOSTNAME environmental variable not being set. I think CRON sessions don't have the full BASH environmental variables set.