### PR TITLE
SVCPLAN-650 Backup ED25519 hostkeys

### DIFF
--- a/cron_scripts/backup-node_configs.sources
+++ b/cron_scripts/backup-node_configs.sources
@@ -1,3 +1,5 @@
 /etc/puppetlabs/puppet/ssl
 /etc/puppetlabs/puppet/puppet.conf
 /etc/krb5.keytab
+/etc/ssh/ssh_host_ed25519_key
+/etc/ssh/ssh_host_ed25519_key.pub


### PR DESCRIPTION
xcat deploys common hostkeys for ECDSA and RSA, but the ED25519
key will be unique for each node and also change after a reboot

This will cause key mismatch warnings when the key changes

Setup xcat-tools to backup the ED25519 keys