### PR TITLE
SVCPLAN-851: Add custom yum_upgrade postscript can run as last postscript

### DIFF
--- a/postscripts/rhel_eus
+++ b/postscripts/rhel_eus
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+###
+# Description: Set RHEL subscription to a specific EUS (Extended Update Support) version
+#
+# Usage:
+#      1. updatenode <noderange> -P "rhel_eus [OPTS]"
+#
+# Source: https://github.com/ncsa/xcat-tools
+###
+
+
+# PREP
+PRG=$( basename $0 )
+logger -t xcat -p local4.info "running '$PRG' on node $NODE"
+
+
+# DEFAULT SETTINGS
+declare -A DEFAULTS
+DEFAULTS[VERSION]=$(grep '^VERSION_ID' /etc/os-release | awk -F'=' ' gsub(/"/,"") { print $2}')
+
+
+# GLOBAL SETTINGS
+
+
+# FUNCTIONS
+logr() {
+  logger -t xcat -p local4.info "$*"
+  echo "$*"
+}
+
+
+croak() {
+  logr "ERROR - $*"
+  echo "ERROR - $*"
+  exit 99
+}
+
+
+rhel_eus() {
+    local _version=$1
+    local _major_version=$(echo ${_version} | cut -d. -f1 )
+    logr "About to set version ${_version} in subscription"
+    set -x
+    /sbin/subscription-manager release --set=${_version}
+    /sbin/subscription-manager repos --enable=rhel-${_major_version}-for-x86_64-appstream-eus-rpms
+    /sbin/subscription-manager repos --enable=rhel-${_major_version}-for-x86_64-baseos-eus-rpms
+    /sbin/subscription-manager repos --enable=codeready-builder-for-rhel-${_major_version}-x86_64-eus-rpms
+    set +x
+}
+
+
+print_usage() {
+    cat <<ENDHERE
+Usage:
+    rhel_eus [OPTIONS]
+
+OPTIONS:
+    -h | --help
+        Print usage message and exit
+    -v | --version [VERSION]
+        Specific version of RHEL to set EUS to
+
+ENDHERE
+}
+
+
+# DO WORK
+VERSION=${DEFAULTS[VERSION]}
+ENDWHILE=0
+while [[ $# -gt 0 ]] && [[ $ENDWHILE -eq 0 ]] ; do
+  case $1 in
+    -h|--help)
+        print_usage
+        exit 0
+        ;;
+    -v|--version)
+        VERSION="$2"
+        shift
+        ;;
+    --)
+        ENDWHILE=1
+        ;;
+    -*)
+        croak "Invalid option '$1'"
+        ;;
+     *)
+        ENDWHILE=1
+        break
+        ;;
+  esac
+  shift
+done
+
+logr "Starting rhel EUS"
+rhel_eus $VERSION
+logr "End of rhel EUS"
+
+logr "end of rhel_eus on OS '$OSVER' on node '$NODE'"
+
+exit 0

--- a/postscripts/rhel_release_set
+++ b/postscripts/rhel_release_set
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 ###
-# Description: Set RHEL subscription to a specific EUS (Extended Update Support) version
+# Description: Set RHEL subscription to a specific release EUS (Extended Update Support) version
+#      Defaults to release version of currently installed RHEL.
 #
 # Usage:
-#      1. updatenode <noderange> -P "rhel_eus [OPTS]"
+#      1. updatenode <noderange> -P "rhel_release_set [OPTS]"
 #
 # Source: https://github.com/ncsa/xcat-tools
 ###
@@ -37,7 +38,7 @@ croak() {
 }
 
 
-rhel_eus() {
+rhel_release_set() {
     local _version=$1
     local _major_version=$(echo ${_version} | cut -d. -f1 )
     logr "About to set version ${_version} in subscription"
@@ -53,7 +54,7 @@ rhel_eus() {
 print_usage() {
     cat <<ENDHERE
 Usage:
-    rhel_eus [OPTIONS]
+    rhel_release_set [OPTIONS]
 
 OPTIONS:
     -h | --help
@@ -92,10 +93,10 @@ while [[ $# -gt 0 ]] && [[ $ENDWHILE -eq 0 ]] ; do
   shift
 done
 
-logr "Starting rhel EUS"
-rhel_eus $VERSION
-logr "End of rhel EUS"
+logr "Starting RHEL release set"
+rhel_release_set $VERSION
+logr "End of RHEL release set"
 
-logr "end of rhel_eus on OS '$OSVER' on node '$NODE'"
+logr "end of rhel_release_set on OS '$OSVER' on node '$NODE'"
 
 exit 0

--- a/postscripts/yum_upgrade
+++ b/postscripts/yum_upgrade
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+###
+# Description: Run yum upgrade to upgrade all packages that need updating
+#              Expects that yum and repos are already installed and configured.
+#              Will schedule a reboot after the yum upgrade.
+# Usage:
+#      1. updatenode <noderange> -P "yum_upgrade [OPTS]"
+#
+# Source: https://github.com/ncsa/xcat-tools
+###
+
+
+# PREP
+PRG=$( basename $0 )
+logger -t xcat -p local4.info "running '$PRG' on node $NODE"
+
+
+# DEFAULT SETTINGS
+declare -A DEFAULTS
+DEFAULTS[DISABLE_EXCLUDES]=all
+
+
+# GLOBAL SETTINGS
+
+
+# FUNCTIONS
+logr() {
+  logger -t xcat -p local4.info "$*"
+  echo "$*"
+}
+
+
+croak() {
+  logr "ERROR - $*"
+  echo "ERROR - $*"
+  exit 99
+}
+
+
+yum_upgrade() {
+    local _disable_excludes=$1
+    #local _env
+    logr "About to run yum upgrade"
+    set -x
+    /bin/yum upgrade -y --disableexcludes=${_disable_excludes}
+    set +x
+}
+
+
+schedule_reboot() {
+    logr "Scheduling reboot in 2 minutes"
+    set -x
+    /sbin/shutdown -r +2 "Reboot after yum upgrade"
+    set +x
+}
+
+
+print_usage() {
+    cat <<ENDHERE
+Usage:
+    yum_upgrade [OPTIONS]
+
+OPTIONS:
+    -h | --help
+        Print usage message and exit
+    -d | --disableexludes [all|main|repoid]
+        Disable the excludes defined in your config files. Takes one of three options:
+          all == disable all excludes
+          main == disable excludes defined in [main] in yum.conf
+          repoid == disable excludes defined for that repo
+
+ENDHERE
+}
+
+
+# DO WORK
+DISABLE_EXCLUDES=${DEFAULTS[DISABLE_EXCLUDES]}
+ENDWHILE=0
+while [[ $# -gt 0 ]] && [[ $ENDWHILE -eq 0 ]] ; do
+  case $1 in
+    -h|--help)
+        print_usage
+        exit 0
+        ;;
+    -d|--disableexcludes)
+        DISABLE_EXCLUDES="$2"
+        shift
+        ;;
+    --)
+        ENDWHILE=1
+        ;;
+    -*)
+        croak "Invalid option '$1'"
+        ;;
+     *)
+        ENDWHILE=1
+        break
+        ;;
+  esac
+  shift
+done
+
+logr "Starting yum upgrade"
+yum_upgrade $DISABLE_EXCLUDES
+logr "End of yum upgrade"
+
+# FOLLOWING CHECK DOES NOT SEEM SUFFICIENT
+# FOR NOW WE WILL ALWAYS REBOOT
+#[ $(/bin/needs-restarting -r >/dev/null ) ] && {
+    logr "Starting scheduling shutdown reboot"
+    schedule_reboot
+    logr "End of scheduling shutdown reboot"
+#}
+
+logr "end of yum_upgrade on OS '$OSVER' on node '$NODE'"
+
+exit 0
+


### PR DESCRIPTION
Add the following postscripts:
- `rhel_release_set` - set to specific RHEL EUS version, requires use of `register_rhel` first
- `yum_upgrade` - upgrade packages via yum, then schedule reboot, mainly useful for stateful nodes not running a built os image - should be last postbootscript if used

These have been tested extensively via `asd-prov01` with the `cmdb-dev-alinab` VM.