### PR TITLE
SVCPLAN-5104: update disable_ipv6 postscript to handle bonds

### DIFF
--- a/postscripts/disable_ipv6
+++ b/postscripts/disable_ipv6
@@ -27,7 +27,7 @@
 
 set -x
 
-active_ethernet_connections=$(nmcli -f DEVICE,TYPE -t connection show --active | grep ethernet | awk -F':' '{print $1}')
+active_ethernet_connections=$(nmcli -f DEVICE,TYPE,NAME -t connection show --active | egrep "ethernet|bond" | grep -v slave | awk -F':' '{print $1}')
 
 for i in $active_ethernet_connections; do
     nmcli device modify $i ipv6.method "disabled"


### PR DESCRIPTION
To handle bonds and slaves we must update the logic for active_ethernet_connections as follows:
(1) grep for "bond" as well as "ethernet" (bonds have type "bond"); (2) include the "NAME" field in nmcli "show" output, so that we can
    identify slaves;
(3) "grep -v slave" to ignore bonds (it is not relevant to disable IPv6
    on a slave and trying to do so results in an error)