### PR TITLE
SVCPLAN-5154: Add a firmware version check for Dell nodes

### DIFF
--- a/admin_scripts/Dell/firmware_version_check.sh
+++ b/admin_scripts/Dell/firmware_version_check.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# SVCPLAN-5154: Dell firmware version check
+# Takes a node range as input, and uses racadm to list out hardware type, bios version and iDRAC version.
+
+racadmpath=/root/xcat-tools/admin_scripts/Dell/racadm.sh
+
+# If user does not provide a node range, prompt them for one here. Invalid entries will cause the script to run against all nodes.
+if [ -z "$1" ]; then
+  read -p "Please enter a node range: " RANGE
+else
+  RANGE=$1
+fi
+
+# Assign the node range into an array to loop through
+readarray -t ARRAY < <(nodels $RANGE)
+
+# Find longest node name for dynamic width formatting
+max=-1
+for i in "${ARRAY[@]}"
+  do
+    len=${#i}
+    ((len > max)) && max=$len
+done
+
+# Print table headers with formatting
+printf "Running scan on noderange: $RANGE \n"
+printf "%*s %10s %-15s %-19s %-20s \n" "$max" "Nodename" ""  "Bios" "iDRAC" "Model"
+printf "__________________________________________________________________________\n"
+
+for i in "${ARRAY[@]}"
+do
+  # Run racadm <node> getversion and pull bios & iDRAC versions. Store these into a temp array for formatting.
+  readarray -t TEMP < <(timeout 15 /bin/bash $racadmpath $i getversion | egrep -i 'bios|idrac' | sort -V | awk '{print $NF}' | head -n 2)
+
+  printf "%*s %10s %-15s %-15s" "$max" "$i" "" "${TEMP[0]}" "${TEMP[1]}"
+  printf "%-5s"
+
+  # Pull hardware model number through dmidecode, and filter out "Poweredge" out of model name.
+  timeout 15 ssh $i dmidecode -s system-product-name | awk '{ print $2 }'
+
+done


### PR DESCRIPTION
https://jira.ncsa.illinois.edu/browse/SVCPLAN-5154 

Adding a bash script that takes (or prompts for) a node range, and uses racadm & dmidecode to output the node's BIOS version, iDRAC version and hardware model.

Script has been tested on mg-adm01, some sample output below (named dellcheck to differentiate as a draft copy)
```
[root@mg-adm01 scripts]# ./dellcheck.sh 
Please enter a node range: test
Running scan on noderange: test
       Nodename            Bios            iDRAC               Model                
__________________________________________________________________________
      mgportal2            2.18.1          2.85.85.85          R730
          mgrs2            2.14.1          7.10.30.00          R7515
       mgsched2            2.14.1          7.10.30.00          R7515
       mgtest01            2.14.1          7.10.30.00          R7525
       mgtest02            2.14.1          7.10.30.00          R7515
       mgtest03            2.14.1          7.10.30.00          R7515
```
```
[root@mg-adm01 scripts]# ./dellcheck.sh slurmd
Running scan on noderange: slurmd 
       Nodename            Bios            iDRAC               Model                
__________________________________________________________________________
          mg001            2.21.0          7.00.00.171         C6420
          mg002            2.21.0          7.00.00.171         C6420
          mg003            2.21.0          7.00.00.171         C6420
          mg004            2.21.0          7.00.00.171         C6420
```

