### PR TITLE
SVCPLAN-7350: Cleanup output for Dell Firmware Check

### DIFF
--- a/admin_scripts/Dell/firmware_version_check.sh
+++ b/admin_scripts/Dell/firmware_version_check.sh
@@ -25,7 +25,7 @@ done
 
 # Print table headers with formatting
 printf "Running scan on noderange: $RANGE \n"
-printf "%*s %10s %-15s %-19s %-20s \n" "$max" "Nodename" ""  "Bios" "iDRAC" "Model"
+printf "%*s %10s %-15s %-19s %-20s \n" "$max" "Node" ""  "Bios" "iDRAC" "Model"
 printf "__________________________________________________________________________\n"
 
 for i in "${ARRAY[@]}"
@@ -37,6 +37,13 @@ do
   printf "%-5s"
 
   # Pull hardware model number through dmidecode, and filter out "Poweredge" out of model name.
-  timeout 15 ssh $i dmidecode -s system-product-name | awk '{ print $2 }'
+  model=$(timeout 15 ssh $i dmidecode -s system-product-name | awk '{ print $2 }')
+
+  # If the above command times out, print that it timed out
+  if [ -z "$model" ]; then
+    printf "Timed Out \n"
+  else
+    printf "%s \n" "$model"
+  fi
 
 done

--- a/admin_scripts/Dell/firmware_version_check.sh
+++ b/admin_scripts/Dell/firmware_version_check.sh
@@ -41,9 +41,9 @@ do
 
   # If the above command times out, print that it timed out
   if [ -z "$model" ]; then
-    printf "Timed Out \n"
+    printf "Timed Out\n"
   else
-    printf "%s \n" "$model"
+    printf "%s\n" "$model"
   fi
 
 done


### PR DESCRIPTION
Currently, if "ssh [node] dmidecode" takes longer than 15 seconds to complete (as it may do during a PM), the command will return an empty string and continue printing information from the next node on the same line. This fix will instead print "Timed Out" with a new line character to preserve formatting. 

Changing "Nodename" to "Node" as the former would cause slight formatting offset when all members of the noderange were less than 8 characters.

Tested on mg-adm01 against various noderanges.