### PR TITLE
SVCPLAN-7242: Add ansible postscripts

### DIFF
--- a/postscripts/ansible_playbook
+++ b/postscripts/ansible_playbook
@@ -1,0 +1,190 @@
+#!/bin/bash
+
+###
+# Description: Run ansible-playbook against the locally synced ansible repo and vault password
+# 
+# This script does the following:
+# 1. Install ansible and prerequisites.
+# 2. Determine which Ansible groups match up with node's xCAT groups.
+# 3. Update Ansible local inventory file to set the Ansible group from xCAT group
+# 4. Determine which Ansible project repo to use.
+# 5. Determine and checkout which branch of the Ansible project repo to use.
+# 6. Run ansible-playbook on the deployed node, logging output to:
+#      /root/xcat_ansible_playbook_output.txt
+#
+# See: https://wiki.ncsa.illinois.edu/display/ICI/Create+a+new+Ansible+Project#CreateanewAnsibleProject-OnxCATServer
+# 
+# Source: https://github.com/ncsa/xcat-tools
+###
+
+set -x
+# Set to 0 : Exit code of the playbook run does not influence the exit code of this postscript
+# Set to 1 : This postscript will exit with the same exit code as the playbook
+IGNORE_PLAYBOOK_EXIT_CODE=1
+
+EPEL_PKG_NAME="epel-release"
+EPEL_PKG_URL="https://dl.fedoraproject.org/pub/epel/epel-release-latest-`awk -F'release ' '{print $2}' /etc/redhat-release | cut -d'.' -f1`.noarch.rpm"
+
+HOSTNAME=`hostname -s`
+logger -t xcat "$0: running $0 on `hostname`"
+source /xcatpost/custom/functions
+
+# FUNCTIONS
+
+logr() {
+  logger -t xcat -p local4.info "$*"
+  echo "$*"
+}
+
+
+croak() {
+  logr "ERROR - $*"
+  echo "ERROR - $*"
+  exit 99
+}
+
+is_ansible_installed() {
+    logr "is ansible installed"
+    dnf list installed ansible > /dev/null 2>&1
+    local _rc=$?
+    [[ $_rc -eq 0 ]] && logr '...yes' || logr '...NO'
+    return $_rc
+}
+
+is_ansible_available() {
+    logr "is ansible available"
+    dnf list available ansible > /dev/null 2>&1 
+    local _rc=$?
+    [[ $_rc -eq 0 ]] && logr '...yes' || logr '...NO'
+    return $_rc
+}
+
+trace-begin $0
+
+trace $0 "Installing dependency packages: ansible, git"
+# IF ansible NOT INSTALLED, INSTALL IT
+is_ansible_installed || ( is_ansible_available && dnf install -y ansible )
+# IF ansible NOT AVAILABLE FROM DEFAULT REPOS TEMPORARILY INSTALL EPEL IN ORDER TO INSTALL ANSIBLE
+is_ansible_installed || ( dnf install -y ${EPEL_PKG_URL} && TEMP_EPEL_INSTALL=1 && dnf install -y ansible )
+is_ansible_installed || croak "Cannot install ansible"
+
+# IF git NOT INSTALLED, INSTALL IT
+dnf list installed git || ( dnf install -y git && TEMP_GIT_INSTALL=1 )
+# IF epel WAS INSTALLED HERE REMOVE IT NOW THAT THE PACKAGES WERE INSTALLED
+if [ "${TEMP_EPEL_INSTALL:-0}" -eq 1 ]; then
+    dnf remove -y "$EPEL_PKG_NAME"
+    trace $0 "Removed EPEL that was temporarily installed in order to install ansible"
+fi
+trace $0 "Finished installing dependency packages: ansible, git"
+
+# GET NODE'S groups FROM xCAT FILTERING OUT ANY ANS* GROUPS
+GROUPJSON=$(echo "$GROUP" | tr ',' '\n' | grep -v '^ANS' | tr '\n' ',' | sed 's/,$//' | sed "s/,/','/g" | sed "s/^/['/" | sed "s/$/']/")
+trace $0 "$HOSTNAME belongs to groups: $GROUPJSON"
+
+# FIGURE OUT WHAT ANSIBLE PROJECT TO USE
+# DEFAULT PROJECT SHOULD BE SET IN SITE TABLE
+# CAN BE OVERRIDDEN BY NODE GROUP VARIABLE
+if [[ $GROUP == *"ANSPROJ_"* ]]; then
+    ANSIBLE_PROJECT=$(echo "$GROUP" | grep -o 'ANSPROJ_[^,]*' | cut -d'_' -f2)
+    trace $0 "Using ansible project: $ANSIBLE_PROJECT set from group ANSPROJ_*"
+elif [[ -n $ANSIBLEPROJECT ]]; then
+    ANSIBLE_PROJECT=$ANSIBLEPROJECT
+    trace $0 "Using ansible project: $ANSIBLE_PROJECT set from xCAT site table"
+else
+    ANSIBLE_PROJECT="control-ansible"
+    trace $0 "Using ansible project: $ANSIBLE_PROJECT set from default in postscript"
+fi
+
+ANSIBLEPATH="/root/ansible/${ANSIBLE_PROJECT}"
+trace $0 "Using path: $ANSIBLEPATH"
+PASSWORD="${ANSIBLEPATH}-vault-password"
+trace $0 "Using password file: $PASSWORD"
+chmod 0400 $PASSWORD
+
+# FIGURE OUT WHAT ANSIBLE PROJECT GIT BRANCH TO USE
+# DEFAULT BRANCH SHOULD BE SET IN SITE TABLE
+# CAN BE OVERRIDDEN BY NODE GROUP VARIABLE - SWAP '/' WITH '.' IN xCAT
+if [[ $GROUP == *"ANSBRANCH_"* ]]; then
+    ANSIBLE_BRANCH=$(echo "$GROUP" | grep -o 'ANSBRANCH_[^,]*' | cut -d'_' -f2  | tr '.' '/')
+    trace $0 "Using ansible branch: $ANSIBLE_BRANCH set from group ANSBRANCH_*"
+elif [[ -n $ANSIBLEPROJECTBRANCH ]]; then
+    ANSIBLE_BRANCH=$(echo $ANSIBLEPROJECTBRANCH | tr '.' '/')
+    trace $0 "Using ansible branch: $ANSIBLE_BRANCH set from xCAT site table"
+else
+    ANSIBLE_BRANCH="main"
+    trace $0 "Using ansible branch: $ANSIBLE_BRANCH set from default in postscript"
+fi
+trace $0 "Checking out $ANSIBLE_PROJECT branch $ANSIBLE_BRANCH"
+cd $ANSIBLEPATH && git checkout ${ANSIBLE_BRANCH} 
+
+# IF git WAS INSTALLED HERE REMOVE IT NOW THAT THE PACKAGES WERE INSTALLED
+if [ "${TEMP_GIT_INSTALL:-0}" -eq 1 ]; then
+    dnf remove -y git
+    trace $0 "Removed git that was temporarily installed to support ansible"
+fi
+
+# wglick - 2025-03-25
+# IS THE FOLLOWING REALLY THE BEST LOGIC FOR SETTING ANSIBLE CHILDREN/GROUPS?
+# - DO WE WANT TO LOOK AT ANSIBLE GROUPS ONLY FROM inventory/group_vars/?
+#   - WHAT IF WE HAVE A VALID ANSIBLE GROUP WITHOUT UNIQUE group_var DATA?
+# - AND/OR DO WE WANT TO LOOK IN inventory/*.yml
+#   - THIS WOULD LET US SET BY hostname INSTEAD OF XCAT GROUP
+
+# CUSTOMIZE inventory/local.yml TO HAVE CHILDREN THAT MATCH HOSTS GROUPS
+# Directory containing the .yml files
+directory="$ANSIBLEPATH/inventory/group_vars/"
+# Array to store the basenames of .yml files
+yml_files=()
+# Loop through the .yml files in the directory
+for file in "$directory"*.yml; do
+  # Exclude 'all.yml'
+  if [[ $(basename "$file") != "all.yml" ]]; then
+    # Get the basename without the .yml extension and add it to the array
+    yml_files+=("$(basename "$file" .yml)")
+  fi
+done
+trace $0 "Ansible inventory has these group_vars: ${yml_files[@]}"
+# Convert GROUP variable to an array
+IFS=',' read -r -a group_array <<< "$GROUP"
+trace $0 "$HOSTNAME belongs to xcat groups: ${group_array[@]}"
+# Find the intersection of group_array and yml_files
+CHILDREN=()
+for group in "${group_array[@]}"; do
+  for yml in "${yml_files[@]}"; do
+    if [[ "$group" == "$yml" ]]; then
+      CHILDREN+=("$group")
+    fi
+  done
+done
+trace $0 "$HOSTNAME belongs to ansible groups: ${CHILDREN[@]}"
+echo "  children:" >> $ANSIBLEPATH/inventory/local.yml
+# Loop over each CHILDREN element to echo some content
+for child in "${CHILDREN[@]}"; do
+  trace $0 "Processing $child"
+  echo "    $child:" >> $ANSIBLEPATH/inventory/local.yml
+  echo "      hosts:" >> $ANSIBLEPATH/inventory/local.yml
+  echo "        local:" >> $ANSIBLEPATH/inventory/local.yml
+done
+
+ANSIBLECOMMAND="ansible-playbook -i inventory/local.yml playbooks/site.yml --vault-password-file $PASSWORD "
+trace $0 "Running ansible-playbook as follows:"
+trace $0 "  $ANSIBLECOMMAND | "
+cd $ANSIBLEPATH
+$ANSIBLECOMMAND &> /root/xcat_ansible_playbook_output.txt
+ANSIBLE_PLAYBOOK_EXIT_CODE=$?
+if [[ $ANSIBLE_PLAYBOOK_EXIT_CODE -eq 0 ]]; then
+  trace $0 "Finished running ansible-playbook - Run was successful"
+else
+  trace $0 "Finished running ansible-playbook - Playbook exited non-zero: $ANSIBLE_PLAYBOOK_EXIT_CODE"
+fi
+
+#trace $0 "Cleanup ansible stuff"
+# WE COULD OPTIONALLY...
+#   REMOVE ansible PACKAGE
+#   REMOVE /root/ansible
+
+trace-end $0
+
+if [[ $IGNORE_PLAYBOOK_EXIT_CODE -eq 1 ]]; then
+  exit $ANSIBLE_PLAYBOOK_EXIT_CODE
+fi

--- a/postscripts/ansible_sync
+++ b/postscripts/ansible_sync
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+###
+# Description: Sync ansible repo and vault password from xCAT server to deployed node
+#
+# Syncs ansible project repo and ansible vault password from /install/ansible on xCAT
+# to /root/ansible on the deployed node.  This allows postscript custom/ansible_playbook
+# to use the local ansible files synced to the server to run ansible playbook using
+# those files during the initial xCAT deployment postscript process.
+#
+# See: https://wiki.ncsa.illinois.edu/display/ICI/Create+a+new+Ansible+Project#CreateanewAnsibleProject-OnxCATServer
+# 
+# Source: https://github.com/ncsa/xcat-tools
+###
+
+set -x
+
+SOURCE_DIR="/install/ansible"
+TARGET_DIR="/root/ansible"
+
+# PREP
+PRG=$( basename $0 )
+logger -t xcat -p local4.info "$PRG: running '$PRG' on node $NODE"
+source /xcatpost/custom/functions
+trace-begin $PRG
+
+logger -t xcat -p local4.info "$PRG: /install mount: $(df -hP /install | grep install)"
+mount | grep "$MASTER:$INSTALLDIR on /install" && logger -t xcat -p local4.info "$PRG: $MASTER:$INSTALLDIR is already mounted"
+mount | grep "$MASTER:$INSTALLDIR on /install" || /xcatpost/mountinstall
+
+# FIGURE OUT WHAT ANSIBLE PROJECT TO USE
+# DEFAULT PROJECT SHOULD BE SET IN SITE TABLE
+# CAN BE OVERRIDDEN BY NODE GROUP VARIABLE
+if [[ $GROUP == *"ANSPROJ_"* ]]; then
+    ANSIBLE_PROJECT=$(echo "$GROUP" | grep -o 'ANSPROJ_[^,]*' | cut -d'_' -f2)
+    trace $PRG "Using ansible project: $ANSIBLE_PROJECT set from group ANSPROJ_*"
+elif [[ -n $ANSIBLEPROJECT ]]; then
+    ANSIBLE_PROJECT=$ANSIBLEPROJECT
+    trace $PRG "Using ansible project: $ANSIBLE_PROJECT set from xCAT site table"
+else
+    ANSIBLE_PROJECT="control-ansible"
+    trace $PRG "Using ansible project: $ANSIBLE_PROJECT set from default in postscript"
+fi
+
+PASSWORD="${ANSIBLE_PROJECT}-vault-password"
+
+#mkdir -p ${TARGET_DIR}/${ANSIBLE_PROJECT}
+mkdir -p ${TARGET_DIR}/
+
+cp -apr ${SOURCE_DIR}/${ANSIBLE_PROJECT} ${TARGET_DIR}/ \
+  && trace $PRG "Copied ${SOURCE_DIR}/${ANSIBLE_PROJECT} to ${TARGET_DIR}/" \
+  || trace $PRG "Failed to copy ${SOURCE_DIR}/${ANSIBLE_PROJECT} to ${TARGET_DIR}/"
+# USING rsync SOMEHOW BREAKS THINGS NETWORKING AFTER THE HOST REBOOTS
+#rsync -av ${SOURCE_DIR}/${ANSIBLE_PROJECT} ${TARGET_DIR}/
+
+cp -apr ${SOURCE_DIR}/${PASSWORD} ${TARGET_DIR}/ \
+  && trace $PRG "Copied ${SOURCE_DIR}/${PASSWORD} to ${TARGET_DIR}/" \
+  || trace $PRG "Failed to copy  ${SOURCE_DIR}/${PASSWORD} to ${TARGET_DIR}/"
+chmod 0400 ${TARGET_DIR}/${PASSWORD}
+
+logger -t xcat -p local4.info "$PRG: end of '$PRG'"
+trace-end $PRG
+
+set +x
+
+exit 0

--- a/postscripts/ansible_user
+++ b/postscripts/ansible_user
@@ -1,0 +1,153 @@
+#!/bin/bash
+
+###
+# Description: Setup ansible user for use by Ansible
+#
+# You must provide the ansible user's authorized ssh keys via the xCAT site table.
+# Set the following site table variable as follows:
+#   "ansibleauthkeys","ssh-rsa AAAAB... root@xcat.local,ssh-ed25519 AAAAC... ansible@ansible.local",,
+#
+# This configuration eventually gets a more hardened configuration via an Ansible
+# playbook.  But this script gets the basics in place so that the ansible user can
+# be used for initial Ansible tasks.
+#
+# This script skips restricting access to only from specific addresses.
+# It skips:
+#   - CIDRs in SSHd match block
+#   - Setup of firewall rules
+#   - Entries in pam security access.conf
+#
+# Source: https://github.com/ncsa/xcat-tools
+###
+
+set -x
+
+logger -t xcat "$0: running $0 on `hostname`"
+source /xcatpost/custom/functions
+
+trace-begin $0
+
+# Define variables (replace these with actual values or source from a config file)
+ANSIBLE_USER_NAME="ansible"
+ANSIBLE_USER_GROUP="ansible"
+ANSIBLE_USER_COMMENT="Ansible Automation User"
+ANSIBLE_USER_DEFAULT_UID=59211
+ANSIBLE_USER_HOME="/home/$ANSIBLE_USER_NAME"
+
+# Default values
+ANSIBLE_USER_UID=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --uid)
+            ANSIBLE_USER_UID="$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+# Fallback to environment variables if not set
+ANSIBLE_USER_UID="${ANSIBLE_USER_UID:-${ANSIBLEUID:-$ANSIBLE_USER_DEFAULT_UID}}"
+
+AUTH_KEYS="${ANSIBLEAUTHKEYS}"
+
+if [ -z "$AUTH_KEYS" ]; then
+    echo "Error: Authorized keys entries not specified. Set ansibleauthkeys in xCAT site table."
+    exit 1
+fi
+
+if [ -z "$ANSIBLE_USER_UID" ]; then
+    echo "Error: Ansible user uid not specified. Use --uid or set ansibleuid in xCAT site table."
+    exit 1
+fi
+
+# Add group
+if ! getent group "$ANSIBLE_USER_GROUP" > /dev/null; then
+  groupadd --system "$ANSIBLE_USER_GROUP"
+  trace $0 "Added group $ANSIBLE_USER_GROUP"
+fi
+
+# Add user
+if ! id "$ANSIBLE_USER_NAME" > /dev/null 2>&1; then
+  useradd -m -c "$ANSIBLE_USER_COMMENT" -g "$ANSIBLE_USER_GROUP" -s /bin/bash -u "$ANSIBLE_USER_UID" "$ANSIBLE_USER_NAME"
+  trace $0 "Added user $ANSIBLE_USER_NAME"
+fi
+
+# Create .ssh directory
+mkdir -p "$ANSIBLE_USER_HOME/.ssh"
+chown "$ANSIBLE_USER_NAME:$ANSIBLE_USER_GROUP" "$ANSIBLE_USER_HOME/.ssh"
+chmod 700 "$ANSIBLE_USER_HOME/.ssh"
+
+# Add authorized_keys
+trace $0 "Using AUTH_KEYS: ${AUTH_KEYS}"
+# Convert comma-separated string to array using a loop
+AUTH_KEYS_ARRAY=()
+while IFS=',' read -ra keys; do
+  for key in "${keys[@]}"; do
+    AUTH_KEYS_ARRAY+=("$key")
+  done
+done <<< "$AUTH_KEYS"
+# Create or clear the authorized_keys file
+: > "$ANSIBLE_USER_HOME/.ssh/authorized_keys"  # Clear file
+for key in "${AUTH_KEYS_ARRAY[@]}"; do
+  echo "$key" >> "$ANSIBLE_USER_HOME/.ssh/authorized_keys"
+done
+# Set correct permissions
+chown "$ANSIBLE_USER_NAME:$ANSIBLE_USER_GROUP" "$ANSIBLE_USER_HOME/.ssh/authorized_keys"
+chmod 600 "$ANSIBLE_USER_HOME/.ssh/authorized_keys"
+trace $0 "Added $ANSIBLE_USER_HOME/.ssh/authorized_keys"
+
+# Add SSHD Match block
+# Define the sshd file path
+SSHD_FILE="/etc/ssh/sshd_config.d/10-ansible.conf"
+mkdir -p /etc/ssh/sshd_config.d
+# ENSURE sshd_config CONTAINS INCLUDE
+CONFIG_FILE="/etc/ssh/sshd_config"
+INCLUDE_LINE="Include /etc/ssh/sshd_config.d/*.conf"
+# Check if the line already exists
+if ! grep -Fxq "$INCLUDE_LINE" "$CONFIG_FILE"; then
+    # Insert the line after the first comment block or at the very top
+    sed -i "1i$INCLUDE_LINE" "$CONFIG_FILE"
+    trace $0 "Added Include line to the top of $CONFIG_FILE"
+fi
+# Write the SSHD config using a here-document
+cat <<EOF > "$SSHD_FILE"
+Match User "$ANSIBLE_USER_NAME" Group "$ANSIBLE_USER_GROUP"
+  AllowGroups $ANSIBLE_USER_GROUP
+  AllowUsers $ANSIBLE_USER_NAME
+  AuthenticationMethods publickey
+  Banner none
+  DisableForwarding no
+  GSSAPIAuthentication no
+  KerberosAuthentication no
+  MaxAuthTries 6
+  MaxSessions 10
+  PasswordAuthentication no
+  PubkeyAuthentication yes
+  X11Forwarding no
+EOF
+# Set correct permissions
+chown root:root "$SSHD_FILE"
+chmod 0600 "$SSHD_FILE"
+systemctl restart sshd
+trace $0 "Added sshd matchblock"
+
+# Configure sudoers
+# Define the sudoers file path
+SUDOERS_FILE="/etc/sudoers.d/10_ansible_user"
+# Write the content directly using a here-document
+cat <<EOF > "$SUDOERS_FILE"
+# ALLOW ANSIBLE GROUP TO SUDO WITHOUT PASSWORD
+Defaults:%${ANSIBLE_USER_GROUP} !mail_always
+Defaults:%${ANSIBLE_USER_GROUP} !requiretty
+%${ANSIBLE_USER_GROUP} ALL=(ALL) NOPASSWD: NOMAIL: ALL
+EOF
+# Set correct permissions
+chown root:root "$SUDOERS_FILE"
+chmod 0440 "$SUDOERS_FILE"
+trace $0 "Added sudoers config"
+
+trace-end $0

--- a/postscripts/ansible_webhook
+++ b/postscripts/ansible_webhook
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+###
+# Description: Call a webhook to trigger an ansible-playbook run for the specific host
+#
+# This script does the following:
+# 1. Install curl and sets HTTPPROXY
+# 2. Calls webhook to run ansible playbook via Semaphore, etc.
+#
+# The webhook URL needs to be set via either:
+# a) command line option -u (takes precedence)
+# b) or the 'ansiblewebhook' value in the xCAT site table, e.g.:
+#   "ansiblewebhook","https://ici-ansible.ncsa.illinois.edu/api/integrations/...",,
+#
+# See:
+# https://wiki.ncsa.illinois.edu/display/AN/Create+a+new+Ansible+Project#CreateanewAnsibleProject-OnxCATServer
+# https://wiki.ncsa.illinois.edu/display/AN/Create+a+new+Ansible+Project#CreateanewAnsibleProject-OnSemaphoreServer
+#
+# Source: https://github.com/ncsa/xcat-tools
+###
+
+set -x
+
+ANSIBLE_START_TIMEOUT=300  # 5 minutes in seconds
+ANSIBLE_ACTIVITY_TIMEOUT=120  # 2 minutes in seconds
+HOSTNAME=`hostname -s`
+logger -t xcat "$0: running $0 on `hostname`"
+source /xcatpost/custom/functions
+
+trace-begin $0
+
+# Initialize WEBHOOK as empty
+WEBHOOK=""
+
+# PARSE COMMAND-LINE OPTIONS
+while getopts "u:h" opt; do
+  case $opt in
+    u)
+      WEBHOOK="$OPTARG"
+      ;;
+    h)
+      echo "Usage: $0 [-u webhook_url]"
+      exit 1
+      ;;
+  esac
+done
+
+# IF -u WAS NOT USED AND ANSIBLEWEBHOOK IS SET, ASSIGN IT TO WEBHOOK
+# ANSIBLEWEBHOOK COMES FROM ansiblewebhook IN XCAT SITE TABLE
+if [ -z "$WEBHOOK" ] && [ -n "$ANSIBLEWEBHOOK" ]; then
+  WEBHOOK="$ANSIBLEWEBHOOK"
+fi
+
+# Check if WEBHOOK is still empty or null
+if [ -z "$WEBHOOK" ]; then
+  trace $0 "WEBHOOK is not set. Use -u or set ANSIBLEWEBHOOK in xCAT site table. Exiting..."
+  exit 1
+fi
+
+trace $0 "WEBHOOK is set to: $WEBHOOK"
+
+trace $0 "Installing dependency packages: curl"
+# IF ansible NOT INSTALLED, INSTALL IT, OPTIONALLY INSTALLING EPEL IN ORDER TO INSTALL IT
+dnf list installed curl || \
+    dnf install -y curl
+trace $0 "Finished installing dependency packages: curl"
+
+trace $0 "Set HTTPPROXY environment variables"
+export ftp_proxy=http://httpproxy.ncsa.illinois.edu:3128/
+export http_proxy=http://httpproxy.ncsa.illinois.edu:3128/
+export https_proxy=http://httpproxy.ncsa.illinois.edu:3128/
+export no_proxy=internal.ncsa.edu,ncsa.illinois.edu,localhost,127.0.0.1
+
+trace $0 "Call ansible/semaphore webhook to run default ansible playbook"
+curl -k -X POST \
+  -H "Content-Type: application/json" \
+  $WEBHOOK \
+  -d "{\"host\":\"${HOSTNAME}*\"}"
+
+#!/bin/bash
+
+# Use tail to follow the log file and grep to filter lines
+trace $0 "Wait for Ansible activity via logs"
+
+LOG_FILE="/var/log/messages"
+START_TIME=$(date +%s)
+LAST_TRACE_TIME=$START_TIME
+TRACE_INTERVAL=30  # seconds
+tail -F "$LOG_FILE" | while read -r line; do
+  CURRENT_TIME=$(date +%s)
+  ELAPSED=$((CURRENT_TIME - START_TIME))
+
+  # Send trace message every TRACE_INTERVAL seconds
+  TRACE_ELAPSED=$((CURRENT_TIME - LAST_TRACE_TIME))
+  if [ "$TRACE_ELAPSED" -ge "$TRACE_INTERVAL" ]; then
+    trace $0 "Still waiting for Ansible activity... elapsed time: ${ELAPSED} seconds"
+    LAST_TRACE_TIME=$CURRENT_TIME
+  fi
+
+  if echo "$line" | grep -iq "python" && echo "$line" | grep -iq "ansible"; then
+    START_TIMESTAMP=$(date -d "$(echo "$line" | awk '{print $1, $2, $3}')" +%s)
+    trace $0 "Detected Ansible playbook activity at timestamp: ${START_TIMESTAMP}"
+    pkill -P $$ tail  # Terminate tail process
+    break
+  fi
+
+  if [ "$ELAPSED" -ge "$ANSIBLE_START_TIMEOUT" ]; then
+    trace $0 "Timeout reached: No Ansible activity detected within ${ANSIBLE_START_TIMEOUT} seconds."
+    pkill -P $$ tail  # Terminate tail process
+    exit 1
+  fi
+done
+
+trace $0 "Wait until we see ansible playbook finished via logs"
+# Now wait for a period of inactivity (e.g., 120 seconds)
+while true; do
+  LAST_ACTIVITY=$(grep -i "python" "$LOG_FILE" | grep -i "ansible" | tail -1)
+  LAST_TIMESTAMP=$(date -d "$(echo "$LAST_ACTIVITY" | awk '{print $1, $2, $3}')" +%s)
+  CURRENT_TIMESTAMP=$(date +%s)
+  DIFF=$((CURRENT_TIMESTAMP - LAST_TIMESTAMP))
+  if [ "$DIFF" -gt "$ANSIBLE_ACTIVITY_TIMEOUT" ]; then
+    trace $0 "No Ansible activity for ${ANSIBLE_ACTIVITY_TIMEOUT} seconds. Assuming playbook has finished."
+    break
+  fi
+  trace $0 "Last Ansible activity timestamp: ${LAST_TIMESTAMP}"  # DO NOT LOG THE ACTIVITY OR LOOKS LIKE NEW ACTIVITY
+  sleep 30  # CHECKS EVERY 30 SECONDS
+done
+
+trace-end $0


### PR DESCRIPTION
- ansible_playbook exit with same exit code as playbook run by default
- Add new ansible_webhook postscript
- Add new ansible_user postscript

This has been tested on `asd-prov01` with the `control-ansible` project repo and the `control-ans-test-*` nodes.

See https://wiki.ncsa.illinois.edu/display/ICI/Create+a+new+Ansible+Project#CreateanewAnsibleProject-OnxCATServer for more context.