### PR TITLE
SVCPLAN-8815 fix backup cleanup bug

### DIFF
--- a/cron_scripts/backup-xcat.sh
+++ b/cron_scripts/backup-xcat.sh
@@ -52,10 +52,10 @@ popd
 find "$SNAPDIR" -delete
 
 # Clean old backups
-find $BACKUPPATH -type f \
+find $BACKUPDIR  -mindepth 1 -maxdepth 1 -type d \
 | sort -r \
 | tail -n +$NUM_OLD_BKUPS_TO_KEEP \
-| xargs -r rm -f
+| xargs -r rm -rf
 
 # Remove empty dirs
 find $BACKUPDIR -type d -empty -delete


### PR DESCRIPTION
backup-xcat.sh was trying to clean up the wrong directory.